### PR TITLE
libva-utils: Remove AC_PROG_LIBTOOL leftover

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,8 +95,8 @@ AC_ARG_ENABLE([tests],
     [], [enable_tests="no"])
 
 
+LT_INIT
 AC_DISABLE_STATIC
-AC_PROG_LIBTOOL
 AC_PROG_CC
 AC_PROG_CXX
 AM_PROG_CC_C_O


### PR DESCRIPTION
This was a leftover from libva split, there are probably
many others uneeded content to remove from configure.ac

fedora-review complain on this old macro - rhbz#1437937

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>