### PR TITLE
putsurface: include wayland-client.h instead of wayland-server.h

### DIFF
--- a/putsurface/putsurface_wayland.c
+++ b/putsurface/putsurface_wayland.c
@@ -31,7 +31,7 @@
 #else
 # include <va/va_wayland.h>
 #endif
-#include <wayland-server.h>
+#include <wayland-client.h>
 
 static void *open_display(void);
 static void close_display(void *win_display);


### PR DESCRIPTION
putsurface_wayland is a wayland client and should not include
the wayland-server.h header file.  Instead, include the
wayland-client.h header instead.

Fixes #34

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>