### PR TITLE
Fix deprecated warning

### DIFF
--- a/encode/avcenc.c
+++ b/encode/avcenc.c
@@ -410,7 +410,7 @@ static void avcenc_update_sei_param(int is_idr)
 				avcenc_context.i_dpb_output_delay_length,
 				&packed_sei_buffer);
 
-	packed_header_param_buffer.type = VAEncPackedHeaderH264_SEI;
+	packed_header_param_buffer.type = VAEncPackedHeaderRawData;
 	packed_header_param_buffer.bit_length = length_in_bits;
 	packed_header_param_buffer.has_emulation_bytes = 0;
 
@@ -1956,8 +1956,9 @@ static void avcenc_context_init(int width, int height)
 
     memset(&use_slot, 0, sizeof(use_slot));
     switch (avcenc_context.profile) {
-    case VAProfileH264Baseline:
+    case VAProfileH264ConstrainedBaseline:
         avcenc_context.constraint_set_flag |= (1 << 0); /* Annex A.2.1 */
+        avcenc_context.constraint_set_flag |= (1 << 1); /* Annex A.2.2 */
         break;
 
     case VAProfileH264Main:

--- a/encode/h264encode.c
+++ b/encode/h264encode.c
@@ -958,7 +958,7 @@ static int process_cmdline(int argc, char *argv[])
             break;
         case 18:
             if (strncmp(optarg, "BP", 2) == 0)
-                h264_profile = VAProfileH264Baseline;
+                h264_profile = VAProfileH264ConstrainedBaseline;
             else if (strncmp(optarg, "MP", 2) == 0)
                 h264_profile = VAProfileH264Main;
             else if (strncmp(optarg, "HP", 2) == 0)
@@ -1047,7 +1047,7 @@ static int process_cmdline(int argc, char *argv[])
 
 static int init_va(void)
 {
-    VAProfile profile_list[]={VAProfileH264High,VAProfileH264Main,VAProfileH264Baseline,VAProfileH264ConstrainedBaseline};
+    VAProfile profile_list[]={VAProfileH264High,VAProfileH264Main,VAProfileH264ConstrainedBaseline};
     VAEntrypoint *entrypoints;
     int num_entrypoints, slice_entrypoint;
     int support_encode = 0;    
@@ -1088,12 +1088,6 @@ static int init_va(void)
         exit(1);
     } else {
         switch (h264_profile) {
-            case VAProfileH264Baseline:
-                printf("Use profile VAProfileH264Baseline\n");
-                ip_period = 1;
-                constraint_set_flag |= (1 << 0); /* Annex A.2.1 */
-                h264_entropy_mode = 0;
-                break;
             case VAProfileH264ConstrainedBaseline:
                 printf("Use profile VAProfileH264ConstrainedBaseline\n");
                 constraint_set_flag |= (1 << 0 | 1 << 1); /* Annex A.2.2 */
@@ -1110,10 +1104,10 @@ static int init_va(void)
                 printf("Use profile VAProfileH264High\n");
                 break;
             default:
-                printf("unknow profile. Set to Baseline");
-                h264_profile = VAProfileH264Baseline;
+                printf("unknow profile. Set to Constrained Baseline");
+                h264_profile = VAProfileH264ConstrainedBaseline;
+                constraint_set_flag |= (1 << 0 | 1 << 1); /* Annex A.2.1 & A.2.2 */
                 ip_period = 1;
-                constraint_set_flag |= (1 << 0); /* Annex A.2.1 */
                 break;
         }
     }
@@ -1695,7 +1689,7 @@ static void render_packedsei(void)
         &packed_sei_buffer);
 
     //offset_in_bytes = 0;
-    packed_header_param_buffer.type = VAEncPackedHeaderH264_SEI;
+    packed_header_param_buffer.type = VAEncPackedHeaderRawData;
     packed_header_param_buffer.bit_length = length_in_bits;
     packed_header_param_buffer.has_emulation_bytes = 0;
 

--- a/encode/svctenc.c
+++ b/encode/svctenc.c
@@ -131,7 +131,6 @@ static float frame_rates[4] = {
 
 static VAProfile g_va_profiles[] = {
     VAProfileH264High,
-    VAProfileH264Baseline,
     VAProfileH264ConstrainedBaseline,
 };
 
@@ -2341,7 +2340,7 @@ svcenc_update_packed_buffers(struct svcenc_context *ctx,
     if (packed_sei_buffer) {
         assert(length_in_bits);
 
-        packed_header_param_buffer.type = VAEncPackedHeaderH264_SEI;
+        packed_header_param_buffer.type = VAEncPackedHeaderRawData;
         packed_header_param_buffer.bit_length = length_in_bits;
         packed_header_param_buffer.has_emulation_bytes = 0;
         va_status = vaCreateBuffer(ctx->va_dpy,
@@ -2474,7 +2473,6 @@ svcenc_update_profile_idc(struct svcenc_context *ctx,
         break;
 
     case VAProfileH264ConstrainedBaseline:
-    case VAProfileH264Baseline:
         ctx->profile_idc = PROFILE_IDC_BASELINE;
         ctx->constraint_set_flag |= (1 << 0 |
                                      1 << 1 |
@@ -2499,11 +2497,6 @@ svcenc_update_profile_idc(struct svcenc_context *ctx,
     case VAProfileH264ConstrainedBaseline:
         ctx->svc_profile_idc = PROFILE_IDC_SCALABLE_BASELINE;
         ctx->svc_constraint_set_flag |= (1 << 0 | 1 << 1 | 1 << 5);
-        break;
-
-    case VAProfileH264Baseline:
-        ctx->svc_profile_idc = PROFILE_IDC_SCALABLE_BASELINE;
-        ctx->svc_constraint_set_flag |= (1 << 0);
         break;
 
     default:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -95,7 +95,6 @@ test_va_api_CPPFLAGS =						\
 
 test_va_api_CXXFLAGS =						\
 	-Wall -Werror						\
-	-Wno-deprecated-declarations				\
 	$(AM_CXXFLAGS)						\
 	$(NULL)
 

--- a/test/test_data.h
+++ b/test/test_data.h
@@ -34,7 +34,6 @@ static const std::vector<VAProfile> m_vaProfiles
         VAProfileMPEG4Simple,
         VAProfileMPEG4AdvancedSimple,
         VAProfileMPEG4Main,
-        VAProfileH264Baseline,
         VAProfileH264Main,
         VAProfileH264High,
         VAProfileVC1Simple,

--- a/test/test_streamable.h
+++ b/test/test_streamable.h
@@ -70,8 +70,6 @@ operator<<(std::ostream& os, const VAProfile& profile)
         return os << "VAProfileVP9Profile2";
     case VAProfileVP9Profile3:
         return os << "VAProfileVP9Profile3";
-    case VAProfileH264Baseline:
-        return os << "VAProfileH264Baseline";
     case VAProfileH264ConstrainedBaseline:
         return os << "VAProfileH264ConstrainedBaseline";
     case VAProfileH264High:

--- a/vainfo/vainfo.c
+++ b/vainfo/vainfo.c
@@ -47,7 +47,6 @@ static char * profile_string(VAProfile profile)
             case VAProfileMPEG4Simple: return "VAProfileMPEG4Simple";
             case VAProfileMPEG4AdvancedSimple: return "VAProfileMPEG4AdvancedSimple";
             case VAProfileMPEG4Main: return "VAProfileMPEG4Main";
-            case VAProfileH264Baseline: return "VAProfileH264Baseline";
             case VAProfileH264Main: return "VAProfileH264Main";
             case VAProfileH264High: return "VAProfileH264High";
             case VAProfileVC1Simple: return "VAProfileVC1Simple";


### PR DESCRIPTION
enums marked as deprecated should not be used any more.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>