### PR TITLE
travis: clone libva v1.8-branch to build libva-utils v1.8-branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - sudo apt-get install -y libxfixes-dev
 
 install:
-  - git clone https://github.com/01org/libva.git
+  - git clone -b v1.8-branch https://github.com/01org/libva.git
   - (cd libva && ./autogen.sh && ./configure --prefix=/usr && sudo make install)
 
 


### PR DESCRIPTION
libva-utils v1.8-branch doesn't work with libva master any more

DO NOT MERGE to master branch!!!

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>