### PR TITLE
test: vaMaxNumConfigAttributes is implementation specific

### DIFF
--- a/test/test_va_api_fixture.cpp
+++ b/test/test_va_api_fixture.cpp
@@ -120,7 +120,7 @@ void VAAPIFixture::doGetMaxNumConfigAttribs()
 {
     m_maxConfigAttributes = vaMaxNumConfigAttributes(m_vaDisplay);
 
-    EXPECT_EQ(m_maxConfigAttributes, 32);
+    EXPECT_TRUE(m_maxConfigAttributes > 0);
 }
 
 void VAAPIFixture::doGetMaxValues()


### PR DESCRIPTION
Don't expect vaMaxNumConfigAttributes to be 32.

vaMaxNumConfigAttributes result is defined by the driver
implementation and may not be the same for all drivers.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>