### PR TITLE
Improve test output logging

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -26,13 +26,21 @@
 #define TEST_H
 
 #include <gtest/gtest.h>
+#include <iostream>
+#include <string>
 #include <va/va.h>
 
 #define EXPECT_STATUS(status) \
-    EXPECT_EQ(VA_STATUS_SUCCESS, (status))
+    EXPECT_EQ(VaapiStatus(VA_STATUS_SUCCESS), VaapiStatus(status))
 
 #define ASSERT_STATUS(status) \
-    ASSERT_EQ(VA_STATUS_SUCCESS, (status))
+    ASSERT_EQ(VaapiStatus(VA_STATUS_SUCCESS), VaapiStatus(status))
+
+#define EXPECT_STATUS_EQ(expect, status) \
+    EXPECT_EQ(VaapiStatus(expect), VaapiStatus(status))
+
+#define ASSERT_STATUS_EQ(expect, status) \
+    ASSERT_EQ(VaapiStatus(expect), VaapiStatus(status))
 
 #define EXPECT_ID(id) \
     EXPECT_NE(VA_INVALID_ID, (id))
@@ -40,10 +48,110 @@
 #define ASSERT_ID(id) \
     ASSERT_NE(VA_INVALID_ID, (id))
 
+#define EXPECT_INVALID_ID(id) \
+    EXPECT_EQ(VA_INVALID_ID, (id))
+
+#define ASSERT_INVALID_ID(id) \
+    ASSERT_EQ(VA_INVALID_ID, (id))
+
 #define EXPECT_PTR(ptr) \
     EXPECT_FALSE(NULL == (ptr))
 
 #define ASSERT_PTR(ptr) \
     ASSERT_FALSE(NULL == (ptr))
+
+#define EXPECT_PTR_NULL(ptr) \
+    EXPECT_TRUE(NULL == (ptr))
+
+#define ASSERT_PTR_NULL(ptr) \
+    ASSERT_TRUE(NULL == (ptr))
+
+class VaapiStatus
+{
+public:
+    explicit VaapiStatus(VAStatus status)
+      : m_status(status)
+    { }
+
+    bool operator ==(const VaapiStatus& other) const
+    {
+        return m_status == other.m_status;
+    }
+
+    friend std::ostream& operator <<(std::ostream& os, const VaapiStatus& t)
+    {
+        std::string status;
+        switch(t.m_status) {
+        case VA_STATUS_SUCCESS:
+            status = "VA_STATUS_SUCCESS"; break;
+        case VA_STATUS_ERROR_OPERATION_FAILED:
+            status = "VA_STATUS_ERROR_OPERATION_FAILED"; break;
+        case VA_STATUS_ERROR_ALLOCATION_FAILED:
+            status = "VA_STATUS_ERROR_ALLOCATION_FAILED"; break;
+        case VA_STATUS_ERROR_INVALID_DISPLAY:
+            status = "VA_STATUS_ERROR_INVALID_DISPLAY"; break;
+        case VA_STATUS_ERROR_INVALID_CONFIG:
+            status = "VA_STATUS_ERROR_INVALID_CONFIG"; break;
+        case VA_STATUS_ERROR_INVALID_CONTEXT:
+            status = "VA_STATUS_ERROR_INVALID_CONTEXT"; break;
+        case VA_STATUS_ERROR_INVALID_SURFACE:
+            status = "VA_STATUS_ERROR_INVALID_SURFACE"; break;
+        case VA_STATUS_ERROR_INVALID_BUFFER:
+            status = "VA_STATUS_ERROR_INVALID_BUFFER"; break;
+        case VA_STATUS_ERROR_INVALID_IMAGE:
+            status = "VA_STATUS_ERROR_INVALID_IMAGE"; break;
+        case VA_STATUS_ERROR_INVALID_SUBPICTURE:
+            status = "VA_STATUS_ERROR_INVALID_SUBPICTURE"; break;
+        case VA_STATUS_ERROR_ATTR_NOT_SUPPORTED:
+            status = "VA_STATUS_ERROR_ATTR_NOT_SUPPORTED"; break;
+        case VA_STATUS_ERROR_MAX_NUM_EXCEEDED:
+            status = "VA_STATUS_ERROR_MAX_NUM_EXCEEDED"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_PROFILE:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_PROFILE"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_BUFFERTYPE:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_BUFFERTYPE"; break;
+        case VA_STATUS_ERROR_SURFACE_BUSY:
+            status = "VA_STATUS_ERROR_SURFACE_BUSY"; break;
+        case VA_STATUS_ERROR_FLAG_NOT_SUPPORTED:
+            status = "VA_STATUS_ERROR_FLAG_NOT_SUPPORTED"; break;
+        case VA_STATUS_ERROR_INVALID_PARAMETER:
+            status = "VA_STATUS_ERROR_INVALID_PARAMETER"; break;
+        case VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED:
+            status = "VA_STATUS_ERROR_RESOLUTION_NOT_SUPPORTED"; break;
+        case VA_STATUS_ERROR_UNIMPLEMENTED:
+            status = "VA_STATUS_ERROR_UNIMPLEMENTED"; break;
+        case VA_STATUS_ERROR_SURFACE_IN_DISPLAYING:
+            status = "VA_STATUS_ERROR_SURFACE_IN_DISPLAYING"; break;
+        case VA_STATUS_ERROR_INVALID_IMAGE_FORMAT:
+            status = "VA_STATUS_ERROR_INVALID_IMAGE_FORMAT"; break;
+        case VA_STATUS_ERROR_DECODING_ERROR:
+            status = "VA_STATUS_ERROR_DECODING_ERROR"; break;
+        case VA_STATUS_ERROR_ENCODING_ERROR:
+            status = "VA_STATUS_ERROR_ENCODING_ERROR"; break;
+        case VA_STATUS_ERROR_INVALID_VALUE:
+            status = "VA_STATUS_ERROR_INVALID_VALUE"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_FILTER:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_FILTER"; break;
+        case VA_STATUS_ERROR_INVALID_FILTER_CHAIN:
+            status = "VA_STATUS_ERROR_INVALID_FILTER_CHAIN"; break;
+        case VA_STATUS_ERROR_HW_BUSY:
+            status = "VA_STATUS_ERROR_HW_BUSY"; break;
+        case VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE:
+            status = "VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE"; break;
+        case VA_STATUS_ERROR_UNKNOWN:
+            status = "VA_STATUS_ERROR_UNKNOWN"; break;
+        default:
+            status = "Unknown VAStatus";
+        }
+        os << status;
+        return os;
+    }
+
+    VAStatus m_status;
+};
 
 #endif // TEST_H

--- a/test/test_va_api_display_attribs.cpp
+++ b/test/test_va_api_display_attribs.cpp
@@ -135,12 +135,12 @@ TEST_F(VAAPIDisplayAttribs, SetDisplayAttribs)
             ASSERT_STATUS(vaSetDisplayAttributes(m_vaDisplay, &attrib, 1));
 
             attrib.value = attrib.min_value - 1;
-            ASSERT_EQ(vaSetDisplayAttributes(m_vaDisplay, &attrib, 1),
-                      VA_STATUS_ERROR_INVALID_PARAMETER);
+            ASSERT_STATUS_EQ(VA_STATUS_ERROR_INVALID_PARAMETER,
+                             vaSetDisplayAttributes(m_vaDisplay, &attrib, 1));
 
             attrib.value = attrib.max_value + 1;
-            ASSERT_EQ(vaSetDisplayAttributes(m_vaDisplay, &attrib, 1),
-                      VA_STATUS_ERROR_INVALID_PARAMETER);
+            ASSERT_STATUS_EQ(VA_STATUS_ERROR_INVALID_PARAMETER,
+                             vaSetDisplayAttributes(m_vaDisplay, &attrib, 1));
         }
     }
 }

--- a/test/test_va_api_init_terminate.cpp
+++ b/test/test_va_api_init_terminate.cpp
@@ -97,7 +97,7 @@ TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate_Bad_Environment)
 
     if (vaDisplay)
 	vaStatus = vaInitialize(vaDisplay, &majorVersion, &minorVersion);
-    EXPECT_EQ(VA_STATUS_ERROR_UNKNOWN, (unsigned)vaStatus);
+    EXPECT_STATUS_EQ(VA_STATUS_ERROR_UNKNOWN, (unsigned)vaStatus);
 
     EXPECT_EQ(0, unsetenv("LIBVA_DRIVER_NAME"));
 
@@ -116,7 +116,7 @@ TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate_Bad_vaSetDriverName)
 
     if (vaDisplay) {
 	vaStatus = vaSetDriverName(vaDisplay, driver);
-	EXPECT_EQ(VA_STATUS_ERROR_INVALID_PARAMETER, vaStatus);
+	EXPECT_STATUS_EQ(VA_STATUS_ERROR_INVALID_PARAMETER, vaStatus);
     }
 }
 
@@ -127,9 +127,9 @@ TEST_F(VAAPIInitTerminate, InitTermWithoutDisplay)
     int majorVersion, minorVersion;
 
     vaStatus = vaInitialize(vaDisplay, &majorVersion, &minorVersion);
-    EXPECT_EQ(VA_STATUS_ERROR_INVALID_DISPLAY, vaStatus);
+    EXPECT_STATUS_EQ(VA_STATUS_ERROR_INVALID_DISPLAY, vaStatus);
 
     vaStatus = vaTerminate(vaDisplay);
-    EXPECT_EQ(VA_STATUS_ERROR_INVALID_DISPLAY, vaStatus);
+    EXPECT_STATUS_EQ(VA_STATUS_ERROR_INVALID_DISPLAY, vaStatus);
 }
 } // namespace VAAPI

--- a/test/test_va_api_query_config.cpp
+++ b/test/test_va_api_query_config.cpp
@@ -69,9 +69,9 @@ TEST_P(VAAPIQueryConfig, CheckEntrypointsForProfile)
             << currentProfile << " is supported but no entrypoints are reported";
     }
     else {
-        ASSERT_EQ(vaQueryConfigEntrypoints(m_vaDisplay, currentProfile,
-                                           &entrypointList[0], &numEntrypoints),
-                  VA_STATUS_ERROR_UNSUPPORTED_PROFILE)
+        ASSERT_STATUS_EQ(VA_STATUS_ERROR_UNSUPPORTED_PROFILE,
+                         vaQueryConfigEntrypoints(m_vaDisplay, currentProfile,
+                                           &entrypointList[0], &numEntrypoints))
             << " profile used is " << currentProfile;
 
         EXPECT_FALSE(numEntrypoints > 0) << currentProfile


### PR DESCRIPTION
Add convenience macros to improve VAStatus logging and other checks.  Also, make sure the order of parameters to test macros are correct.  That is, expected value should be first parameter and actual value should be second parameter

BEFORE:
```
test_va_api_fixture.cpp:503: Failure
      Expected: vaStatus
      Which is: 12
To be equal to: error
      Which is: 13
```
AFTER:
```
test_va_api_fixture.cpp:504: Failure
      Expected: VaapiStatus(error)
      Which is: VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT
To be equal to: VaapiStatus(vaStatus)
      Which is: VA_STATUS_ERROR_UNSUPPORTED_PROFILE
```